### PR TITLE
fix: Fix mtv calculation for both polygon-polygon as well as polygon-circle intersections.

### DIFF
--- a/shape.go
+++ b/shape.go
@@ -671,6 +671,11 @@ func (cp *ConvexPolygon) calculateMTV(contactSet *ContactSet, otherShape IShape)
 
 		}
 
+		// If the direction from target to source points opposite to the separation, invert the separation vector.
+		if cp.Center().Sub(other.Center()).Dot(smallest) < 0 {
+			smallest = smallest.Invert()
+		}
+
 	case *Circle:
 
 		verts := append([]Vector{}, cp.Transformed()...)

--- a/shape.go
+++ b/shape.go
@@ -1193,7 +1193,7 @@ func (projection Projection) Overlapping(other Projection) bool {
 
 // Overlap returns the amount that a Projection is overlapping with the other, provided Projection. Credit to https://dyn4j.org/2010/01/sat/#sat-nointer
 func (projection Projection) Overlap(other Projection) float64 {
-	return math.Min(projection.Max, other.Max) - math.Max(projection.Min, other.Min)
+	return math.Min(projection.Max - other.Min, other.Max - projection.Min)
 }
 
 // IsInside returns whether the Projection is wholly inside of the other, provided Projection.


### PR DESCRIPTION
This fixes the potential incorrect direction of the MTV.

While testing I noticed that polygon-circle intersections have a similar issue once the circles center is inside the polygon.
A naive approach would be to do the same check and set the the magnitude to 2*r - smallest.Magnitude and invert it.
```go
if cp.Center().Sub(other.position).Dot(smallest.Unit()) < 0 {
    smallest = smallest.Unit().Scale(-other.radius * 2 + smallest.Magnitude())
}
```
But that only works if the intersecting points are on the same edge.

