### PR TITLE
circle: correct OtherShape for circle to circle intersections

### DIFF
--- a/shape.go
+++ b/shape.go
@@ -429,7 +429,7 @@ func circleCircleTest(circleA, circleB *Circle) IntersectionSet {
 	dist := intersectionSet.MTV.Magnitude()
 	intersectionSet.MTV = intersectionSet.MTV.Unit().Scale(circleA.radius + circleB.radius - dist)
 
-	intersectionSet.OtherShape = circleA
+	intersectionSet.OtherShape = circleB
 
 	return intersectionSet
 


### PR DESCRIPTION
I was very confused why running with a `ByTag` filter I got some sets with `OtherShape` that didn't have the tag (and didn't have the `Data` I was expecting). This should fix it!